### PR TITLE
More changes related with PF6

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/tableUtils.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/tableUtils.tsx
@@ -65,7 +65,6 @@ export const hostnameColumn = (
       title: t('ai:Hostname'),
       props: {
         id: 'col-header-hostname', // ACM jest tests require id over testId
-        modifier: 'breakWord',
       },
       sort: true,
     },

--- a/libs/ui-lib/lib/common/components/ui/PrismCode.tsx
+++ b/libs/ui-lib/lib/common/components/ui/PrismCode.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Highlight, { defaultProps, Language, PrismTheme } from 'prism-react-renderer';
 import { Content, ClipboardCopy, clipboardCopyFunc } from '@patternfly/react-core';
-import { global_palette_purple_400 } from '@patternfly/react-tokens/dist/js/global_palette_purple_400';
+import { t_global_color_nonstatus_purple_300 } from '@patternfly/react-tokens/dist/js/t_global_color_nonstatus_purple_300';
 import { t_global_color_nonstatus_blue_default as globalBlue } from '@patternfly/react-tokens/dist/js/t_global_color_nonstatus_blue_default';
 import defaultTheme from 'prism-react-renderer/themes/github';
 import './PrismCode.css';
@@ -21,7 +21,7 @@ export const SimpleAIPrismTheme = {
     {
       types: ['class-name', 'function', 'tag', 'attr-name'],
       style: {
-        color: global_palette_purple_400.value,
+        color: t_global_color_nonstatus_purple_300.value,
       },
     },
   ],

--- a/libs/ui-lib/lib/common/components/ui/formik/InputField.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/InputField.tsx
@@ -83,9 +83,13 @@ const InputField: React.FC<
           <FormHelperText>
             <HelperText>
               <HelperTextItem
-                icon={errorMessage && <ExclamationCircleIcon />}
-                variant={showErrorMessage ? 'error' : 'default'}
-                id={showErrorMessage && !isValid ? `${fieldId}-helper-error` : `${fieldId}-helper`}
+                icon={errorMessage && errorMessage.trim() !== '' ? <ExclamationCircleIcon /> : null}
+                variant={errorMessage && errorMessage.trim() !== '' ? 'error' : 'default'}
+                id={
+                  errorMessage && errorMessage.trim() !== ''
+                    ? `${fieldId}-helper-error`
+                    : `${fieldId}-helper`
+                }
               >
                 {showErrorMessage ? errorMessage : helperText}
               </HelperTextItem>


### PR DESCRIPTION
- Change purple color in PrismCode to use the correct one
![image](https://github.com/user-attachments/assets/a670adea-0a4d-4524-a117-53777a21836e)

- https://issues.redhat.com/browse/MGMT-20969: solves problems with hostname column header
![Captura desde 2025-07-07 10-51-50](https://github.com/user-attachments/assets/70329a4b-9f3d-4ed5-abfa-3961007dbcfa)

- https://issues.redhat.com/browse/MGMT-20967: errors beneath text boxes dissapears but icon remains in place
with error:
![image](https://github.com/user-attachments/assets/4eb28dca-e673-4d2a-8975-b14b1e81f76e)

without error:
![image](https://github.com/user-attachments/assets/00a91218-ad94-4b17-987c-2ddfeb8b5ae4)

