### PR TITLE
Fixing PF6 bugs - 4

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewPreflightChecks.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewPreflightChecks.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import {
   Divider,
   ExpandableSection,
+  Flex,
+  FlexItem,
   Grid,
   GridItem,
   gridSpans,
@@ -94,25 +96,25 @@ const PreflightCheckInfo = ({
 }) => {
   return (
     <GridItem span={span} offset={offset} className={className}>
-      <Split hasGutter>
-        <SplitItem>{icon}</SplitItem>
-        <SplitItem>
+      <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+        <FlexItem style={{ display: 'flex', alignItems: 'center' }}>{icon}</FlexItem>
+        <FlexItem style={{ display: 'flex', alignItems: 'center' }}>
           <b>{title}</b>
-        </SplitItem>
-      </Split>
+        </FlexItem>
+      </Flex>
     </GridItem>
   );
 };
 
 const getCheckIcon = (validationStatuses: string[]) => {
   if (validationStatuses.includes('failure') || validationStatuses.includes('error')) {
-    return <UiIcon status="danger" icon={<ExclamationCircleIcon />} />;
+    return <UiIcon size="sm" status="danger" icon={<ExclamationCircleIcon />} />;
   } else if (validationStatuses.includes('warning')) {
-    return <UiIcon status="warning" icon={<ExclamationTriangleIcon />} />;
+    return <UiIcon size="sm" status="warning" icon={<ExclamationTriangleIcon />} />;
   } else if (validationStatuses.includes('pending')) {
-    return <UiIcon status="info" icon={<InfoCircleIcon />} />;
+    return <UiIcon size="sm" status="info" icon={<InfoCircleIcon />} />;
   }
-  return <UiIcon status="warning" icon={<CheckCircleIcon color={okColor.value} />} />;
+  return <UiIcon size="sm" icon={<CheckCircleIcon color={okColor.value} />} />;
 };
 
 const PreflightChecksDetailCollapsed = ({ cluster }: { cluster: Cluster }) => {
@@ -126,9 +128,9 @@ const PreflightChecksDetailCollapsed = ({ cluster }: { cluster: Cluster }) => {
   );
 
   const supportLevelIcon = isFullySupported ? (
-    <CheckCircleIcon color={okColor.value} />
+    <UiIcon size="sm" icon={<CheckCircleIcon color={okColor.value} />} />
   ) : (
-    <InfoCircleIcon color={infoColor.value} />
+    <UiIcon size="sm" icon={<InfoCircleIcon color={infoColor.value} />} />
   );
 
   const clusterValidations = React.useMemo(
@@ -161,12 +163,17 @@ const PreflightChecksDetailCollapsed = ({ cluster }: { cluster: Cluster }) => {
       <PreflightCheckInfo
         title="Cluster preflight checks"
         icon={getCheckIcon(clusterValidations)}
+        span={3}
       />
-      <PreflightCheckInfo title="Host preflight checks" icon={getCheckIcon(hostValidations)} />
+      <PreflightCheckInfo
+        title="Host preflight checks"
+        icon={getCheckIcon(hostValidations)}
+        span={3}
+      />
       <PreflightCheckInfo
         title={`Cluster support level: ${isFullySupported ? 'Full' : 'Limited'}`}
         icon={supportLevelIcon}
-        span={4}
+        span={3}
       />
     </>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -9,7 +9,7 @@ import {
 import { getClusterDetailId } from './utils';
 import { ClustersAPI } from '../../services/apis';
 import ClusterDetailStatusMessages from './ClusterDetailStatusMessages';
-import { Grid } from '@patternfly/react-core';
+import { Stack, StackItem } from '@patternfly/react-core';
 import { getErrorMessage } from '../../../common/utils';
 import {
   Cluster,
@@ -94,20 +94,24 @@ const ClusterDetailStatusVarieties = ({
     consoleOperator?.status === 'available' || (!consoleOperator && cluster.status === 'installed'); // Retain backwards compatibility with clusters which don't have monitored clusters
 
   return (
-    <Grid hasGutter>
+    <Stack hasGutter>
       {showClusterCredentials && (
-        <ClusterCredentials
-          cluster={cluster}
-          credentials={credentials}
-          error={!!credentialsError}
-          retry={fetchCredentials}
-          idPrefix={getClusterDetailId('cluster-creds')}
-          credentialsError={credentialsError}
-          isMceEnabled={hasEnabledOperators(cluster.monitoredOperators, OPERATOR_NAME_MCE)}
-        />
+        <StackItem className="pf-v6-u-mt-lg">
+          <ClusterCredentials
+            cluster={cluster}
+            credentials={credentials}
+            error={!!credentialsError}
+            retry={fetchCredentials}
+            idPrefix={getClusterDetailId('cluster-creds')}
+            credentialsError={credentialsError}
+            isMceEnabled={hasEnabledOperators(cluster.monitoredOperators, OPERATOR_NAME_MCE)}
+          />
+        </StackItem>
       )}
-      <ClusterDetailStatusMessages cluster={cluster} showAddHostsInfo={showAddHostsInfo} />
-    </Grid>
+      <StackItem className="pf-v6-u-mt-lg">
+        <ClusterDetailStatusMessages cluster={cluster} showAddHostsInfo={showAddHostsInfo} />
+      </StackItem>
+    </Stack>
   );
 };
 

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
@@ -64,16 +64,18 @@ const ClusterInstallationProgressCard: React.FC<{ cluster: Cluster }> = ({ clust
       </CardBody>
       <CardExpandableContent>
         <CardBody>
-          <Grid hasGutter>
-            <ClusterDetailStatusVarieties
-              cluster={cluster}
-              clusterVarieties={clusterVarieties}
-              showAddHostsInfo={false}
-            />
-            <GridItem>
+          <Stack hasGutter>
+            <StackItem className="pf-v6-u-mt-lg">
+              <ClusterDetailStatusVarieties
+                cluster={cluster}
+                clusterVarieties={clusterVarieties}
+                showAddHostsInfo={false}
+              />
+            </StackItem>
+            <StackItem className="pf-v6-u-mt-lg">
               <ClusterHostsTable cluster={cluster} skipDisabled />
-            </GridItem>
-          </Grid>
+            </StackItem>
+          </Stack>
         </CardBody>
       </CardExpandableContent>
     </Card>


### PR DESCRIPTION
- https://issues.redhat.com/browse/MGMT-21147: R&C page - missing vertical spacing between kubeconfig warning and buttons

<img width="800" height="209" alt="Captura desde 2025-07-17 13-03-27" src="https://github.com/user-attachments/assets/a30ed18e-8fd2-4c37-911a-bd46ba523b7b" />

- https://issues.redhat.com/browse/MGMT-21151: Inconsistent icon and text alignment across preflight check rows in "Review and create" page

<img width="767" height="71" alt="Captura desde 2025-07-17 15-01-04" src="https://github.com/user-attachments/assets/c80a077b-8d5a-49f0-b565-99931fbbcebf" />
